### PR TITLE
Handle empty responses in `json`

### DIFF
--- a/src/json.js
+++ b/src/json.js
@@ -1,5 +1,8 @@
 function responseJson(response) {
   if (!response.ok) throw new Error(response.status + " " + response.statusText);
+  if (response.status === 204 || response.status === 205) {
+    return null;
+  }
   return response.json();
 }
 


### PR DESCRIPTION
Responses with status 204 and 205 don't contain a body which causes `response.json()` to blow up (unlike `response.text()` et al).

I _think_ the correct way to handle this is to return `null`.