### PR TITLE
Add version info to API reference.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,19 @@ d3.csv("/path/to/file.csv").then(function(data) {
 
 ## API Reference
 
-<a name="blob" href="#blob">#</a> d3.<b>blob</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/blob.js "Source") · Since [v0.1.0](https://github.com/d3/d3-fetch/releases/tag/v0.1.0)
+<a name="blob" href="#blob">#</a> d3.<b>blob</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/blob.js "Source") · Changed [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v0.1.0)
 
 Fetches the binary file at the specified *input* URL as a Blob. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.
 
-<a name="buffer" href="#buffer">#</a> d3.<b>buffer</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/buffer.js "Source") · Since [v0.1.0](https://github.com/d3/d3-fetch/releases/tag/v0.1.0)
+<a name="buffer" href="#buffer">#</a> d3.<b>buffer</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/buffer.js "Source") · Changed [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v0.1.0)
 
 Fetches the binary file at the specified *input* URL as an ArrayBuffer. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.
 
-<a name="csv" href="#csv">#</a> d3.<b>csv</b>(<i>input</i>[, <i>init</i>][, <i>row</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source") · Since [v0.0.1](https://github.com/d3/d3-fetch/releases/tag/v0.0.1)
+<a name="csv" href="#csv">#</a> d3.<b>csv</b>(<i>input</i>[, <i>init</i>][, <i>row</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source") · Changed [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v0.0.1)
 
 Equivalent to [d3.dsv](#dsv) with the comma character as the delimiter.
 
-<a name="dsv" href="#dsv">#</a> d3.<b>dsv</b>(<i>delimiter</i>, <i>input</i>[, <i>init</i>][, <i>row</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source") · Since [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v1.0.0)
+<a name="dsv" href="#dsv">#</a> d3.<b>dsv</b>(<i>delimiter</i>, <i>input</i>[, <i>init</i>][, <i>row</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source") · Added [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v1.0.0)
 
 Fetches the [DSV](https://github.com/d3/d3-dsv) file at the specified *input* URL. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields. An optional *row* conversion function may be specified to map and filter row objects to a more-specific representation; see [*dsv*.parse](https://github.com/d3/d3-dsv#dsv_parse) for details. For example:
 
@@ -69,11 +69,11 @@ If only one of *init* and *row* is specified, it is interpreted as the *row* con
 
 See also [d3.csv](#csv) and [d3.tsv](#tsv).
 
-<a name="html" href="#html">#</a> d3.<b>html</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/xml.js "Source") · Since [v1.1.0](https://github.com/d3/d3-fetch/releases/tag/v1.1.0)
+<a name="html" href="#html">#</a> d3.<b>html</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/xml.js "Source") · Added [v1.1.0](https://github.com/d3/d3-fetch/releases/tag/v1.1.0)
 
 Fetches the file at the specified *input* URL as [text](#text) and then [parses it](https://developer.mozilla.org/docs/Web/API/DOMParser) as HTML. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.
 
-<a name="image" href="#image">#</a> d3.<b>image</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/image.js "Source") · Since [v0.0.2](https://github.com/d3/d3-fetch/releases/tag/v0.0.2)
+<a name="image" href="#image">#</a> d3.<b>image</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/image.js "Source") · Changed [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v0.0.2)
 
 Fetches the image at the specified *input* URL. If *init* is specified, sets any additional properties on the image before loading. For example, to enable an anonymous [cross-origin request](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image):
 
@@ -83,22 +83,22 @@ d3.image("https://example.com/test.png", {crossOrigin: "anonymous"}).then(functi
 });
 ```
 
-<a name="json" href="#json">#</a> d3.<b>json</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/json.js "Source") · Since [v0.0.1](https://github.com/d3/d3-fetch/releases/tag/v0.0.1)
+<a name="json" href="#json">#</a> d3.<b>json</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/json.js "Source") · Changed [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v0.0.1)
 
 Fetches the [JSON](http://json.org) file at the specified *input* URL. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields. If the server returns a status code of [204 No Content](https://developer.mozilla.org/docs/Web/HTTP/Status/204) or [205 Reset Content](https://developer.mozilla.org/docs/Web/HTTP/Status/205), the promise resolves to `undefined`.
 
-<a name="svg" href="#svg">#</a> d3.<b>svg</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/xml.js "Source") · Since [v1.1.0](https://github.com/d3/d3-fetch/releases/tag/v1.1.0)
+<a name="svg" href="#svg">#</a> d3.<b>svg</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/xml.js "Source") · Added [v1.1.0](https://github.com/d3/d3-fetch/releases/tag/v1.1.0)
 
 Fetches the file at the specified *input* URL as [text](#text) and then [parses it](https://developer.mozilla.org/docs/Web/API/DOMParser) as SVG. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.
 
-<a name="text" href="#text">#</a> d3.<b>text</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/text.js "Source") · Since [v0.0.1](https://github.com/d3/d3-fetch/releases/tag/v0.0.1)
+<a name="text" href="#text">#</a> d3.<b>text</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/text.js "Source") · Changed [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v0.0.1)
 
 Fetches the text file at the specified *input* URL. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.
 
-<a name="tsv" href="#tsv">#</a> d3.<b>tsv</b>(<i>input</i>[, <i>init</i>][, <i>row</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source") · Since [v0.0.1](https://github.com/d3/d3-fetch/releases/tag/v0.0.1)
+<a name="tsv" href="#tsv">#</a> d3.<b>tsv</b>(<i>input</i>[, <i>init</i>][, <i>row</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source") · Changed [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v0.0.1)
 
 Equivalent to [d3.dsv](#dsv) with the tab character as the delimiter.
 
-<a name="xml" href="#xml">#</a> d3.<b>xml</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/xml.js "Source") · Since [v1.1.0](https://github.com/d3/d3-fetch/releases/tag/v1.1.0)
+<a name="xml" href="#xml">#</a> d3.<b>xml</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/xml.js "Source") · Added [v1.1.0](https://github.com/d3/d3-fetch/releases/tag/v1.1.0)
 
 Fetches the file at the specified *input* URL as [text](#text) and then [parses it](https://developer.mozilla.org/docs/Web/API/DOMParser) as XML. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.

--- a/README.md
+++ b/README.md
@@ -36,19 +36,19 @@ d3.csv("/path/to/file.csv").then(function(data) {
 
 ## API Reference
 
-<a name="blob" href="#blob">#</a> d3.<b>blob</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/blob.js "Source")
+<a name="blob" href="#blob">#</a> d3.<b>blob</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/blob.js "Source") · Since [v0.1.0](https://github.com/d3/d3-fetch/releases/tag/v0.1.0)
 
 Fetches the binary file at the specified *input* URL as a Blob. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.
 
-<a name="buffer" href="#buffer">#</a> d3.<b>buffer</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/buffer.js "Source")
+<a name="buffer" href="#buffer">#</a> d3.<b>buffer</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/buffer.js "Source") · Since [v0.1.0](https://github.com/d3/d3-fetch/releases/tag/v0.1.0)
 
 Fetches the binary file at the specified *input* URL as an ArrayBuffer. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.
 
-<a name="csv" href="#csv">#</a> d3.<b>csv</b>(<i>input</i>[, <i>init</i>][, <i>row</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source")
+<a name="csv" href="#csv">#</a> d3.<b>csv</b>(<i>input</i>[, <i>init</i>][, <i>row</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source") · Since [v0.0.1](https://github.com/d3/d3-fetch/releases/tag/v0.0.1)
 
 Equivalent to [d3.dsv](#dsv) with the comma character as the delimiter.
 
-<a name="dsv" href="#dsv">#</a> d3.<b>dsv</b>(<i>delimiter</i>, <i>input</i>[, <i>init</i>][, <i>row</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source")
+<a name="dsv" href="#dsv">#</a> d3.<b>dsv</b>(<i>delimiter</i>, <i>input</i>[, <i>init</i>][, <i>row</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source") · Since [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v1.0.0)
 
 Fetches the [DSV](https://github.com/d3/d3-dsv) file at the specified *input* URL. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields. An optional *row* conversion function may be specified to map and filter row objects to a more-specific representation; see [*dsv*.parse](https://github.com/d3/d3-dsv#dsv_parse) for details. For example:
 
@@ -69,11 +69,11 @@ If only one of *init* and *row* is specified, it is interpreted as the *row* con
 
 See also [d3.csv](#csv) and [d3.tsv](#tsv).
 
-<a name="html" href="#html">#</a> d3.<b>html</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/xml.js "Source")
+<a name="html" href="#html">#</a> d3.<b>html</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/xml.js "Source") · Since [v1.1.0](https://github.com/d3/d3-fetch/releases/tag/v1.1.0)
 
 Fetches the file at the specified *input* URL as [text](#text) and then [parses it](https://developer.mozilla.org/docs/Web/API/DOMParser) as HTML. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.
 
-<a name="image" href="#image">#</a> d3.<b>image</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/image.js "Source")
+<a name="image" href="#image">#</a> d3.<b>image</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/image.js "Source") · Since [v0.0.2](https://github.com/d3/d3-fetch/releases/tag/v0.0.2)
 
 Fetches the image at the specified *input* URL. If *init* is specified, sets any additional properties on the image before loading. For example, to enable an anonymous [cross-origin request](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image):
 
@@ -83,22 +83,22 @@ d3.image("https://example.com/test.png", {crossOrigin: "anonymous"}).then(functi
 });
 ```
 
-<a name="json" href="#json">#</a> d3.<b>json</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/json.js "Source")
+<a name="json" href="#json">#</a> d3.<b>json</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/json.js "Source") · Since [v0.0.1](https://github.com/d3/d3-fetch/releases/tag/v0.0.1)
 
 Fetches the [JSON](http://json.org) file at the specified *input* URL. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields. If the server returns a status code of [204 No Content](https://developer.mozilla.org/docs/Web/HTTP/Status/204) or [205 Reset Content](https://developer.mozilla.org/docs/Web/HTTP/Status/205), the promise resolves to `undefined`.
 
-<a name="svg" href="#svg">#</a> d3.<b>svg</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/xml.js "Source")
+<a name="svg" href="#svg">#</a> d3.<b>svg</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/xml.js "Source") · Since [v1.1.0](https://github.com/d3/d3-fetch/releases/tag/v1.1.0)
 
 Fetches the file at the specified *input* URL as [text](#text) and then [parses it](https://developer.mozilla.org/docs/Web/API/DOMParser) as SVG. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.
 
-<a name="text" href="#text">#</a> d3.<b>text</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/text.js "Source")
+<a name="text" href="#text">#</a> d3.<b>text</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/text.js "Source") · Since [v0.0.1](https://github.com/d3/d3-fetch/releases/tag/v0.0.1)
 
 Fetches the text file at the specified *input* URL. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.
 
-<a name="tsv" href="#tsv">#</a> d3.<b>tsv</b>(<i>input</i>[, <i>init</i>][, <i>row</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source")
+<a name="tsv" href="#tsv">#</a> d3.<b>tsv</b>(<i>input</i>[, <i>init</i>][, <i>row</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source") · Since [v0.0.1](https://github.com/d3/d3-fetch/releases/tag/v0.0.1)
 
 Equivalent to [d3.dsv](#dsv) with the tab character as the delimiter.
 
-<a name="xml" href="#xml">#</a> d3.<b>xml</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/xml.js "Source")
+<a name="xml" href="#xml">#</a> d3.<b>xml</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/xml.js "Source") · Since [v1.1.0](https://github.com/d3/d3-fetch/releases/tag/v1.1.0)
 
 Fetches the file at the specified *input* URL as [text](#text) and then [parses it](https://developer.mozilla.org/docs/Web/API/DOMParser) as XML. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.

--- a/README.md
+++ b/README.md
@@ -36,15 +36,15 @@ d3.csv("/path/to/file.csv").then(function(data) {
 
 ## API Reference
 
-<a name="blob" href="#blob">#</a> d3.<b>blob</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/blob.js "Source") · Changed [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v0.1.0)
+<a name="blob" href="#blob">#</a> d3.<b>blob</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/blob.js "Source") · Changed [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v1.0.0)
 
 Fetches the binary file at the specified *input* URL as a Blob. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.
 
-<a name="buffer" href="#buffer">#</a> d3.<b>buffer</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/buffer.js "Source") · Changed [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v0.1.0)
+<a name="buffer" href="#buffer">#</a> d3.<b>buffer</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/buffer.js "Source") · Changed [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v1.0.0)
 
 Fetches the binary file at the specified *input* URL as an ArrayBuffer. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.
 
-<a name="csv" href="#csv">#</a> d3.<b>csv</b>(<i>input</i>[, <i>init</i>][, <i>row</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source") · Changed [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v0.0.1)
+<a name="csv" href="#csv">#</a> d3.<b>csv</b>(<i>input</i>[, <i>init</i>][, <i>row</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source") · Changed [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v1.0.0)
 
 Equivalent to [d3.dsv](#dsv) with the comma character as the delimiter.
 
@@ -73,7 +73,7 @@ See also [d3.csv](#csv) and [d3.tsv](#tsv).
 
 Fetches the file at the specified *input* URL as [text](#text) and then [parses it](https://developer.mozilla.org/docs/Web/API/DOMParser) as HTML. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.
 
-<a name="image" href="#image">#</a> d3.<b>image</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/image.js "Source") · Changed [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v0.0.2)
+<a name="image" href="#image">#</a> d3.<b>image</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/image.js "Source") · Changed [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v1.0.0)
 
 Fetches the image at the specified *input* URL. If *init* is specified, sets any additional properties on the image before loading. For example, to enable an anonymous [cross-origin request](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image):
 
@@ -83,7 +83,7 @@ d3.image("https://example.com/test.png", {crossOrigin: "anonymous"}).then(functi
 });
 ```
 
-<a name="json" href="#json">#</a> d3.<b>json</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/json.js "Source") · Changed [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v0.0.1)
+<a name="json" href="#json">#</a> d3.<b>json</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/json.js "Source") · Changed [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v1.0.0)
 
 Fetches the [JSON](http://json.org) file at the specified *input* URL. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields. If the server returns a status code of [204 No Content](https://developer.mozilla.org/docs/Web/HTTP/Status/204) or [205 Reset Content](https://developer.mozilla.org/docs/Web/HTTP/Status/205), the promise resolves to `undefined`.
 
@@ -91,11 +91,11 @@ Fetches the [JSON](http://json.org) file at the specified *input* URL. If *init*
 
 Fetches the file at the specified *input* URL as [text](#text) and then [parses it](https://developer.mozilla.org/docs/Web/API/DOMParser) as SVG. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.
 
-<a name="text" href="#text">#</a> d3.<b>text</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/text.js "Source") · Changed [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v0.0.1)
+<a name="text" href="#text">#</a> d3.<b>text</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/text.js "Source") · Changed [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v1.0.0)
 
 Fetches the text file at the specified *input* URL. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.
 
-<a name="tsv" href="#tsv">#</a> d3.<b>tsv</b>(<i>input</i>[, <i>init</i>][, <i>row</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source") · Changed [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v0.0.1)
+<a name="tsv" href="#tsv">#</a> d3.<b>tsv</b>(<i>input</i>[, <i>init</i>][, <i>row</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source") · Changed [v1.0.0](https://github.com/d3/d3-fetch/releases/tag/v1.0.0)
 
 Equivalent to [d3.dsv](#dsv) with the tab character as the delimiter.
 

--- a/README.md
+++ b/README.md
@@ -36,19 +36,19 @@ d3.csv("/path/to/file.csv").then(function(data) {
 
 ## API Reference
 
-<a name="blob" href="#blob">#</a> d3.<b>blob</b>(<i>input</i>[, <i>init</i>]) [<>](https://github.com/d3/d3-fetch/blob/master/src/blob.js "Source")
+<a name="blob" href="#blob">#</a> d3.<b>blob</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/blob.js "Source")
 
 Fetches the binary file at the specified *input* URL as a Blob. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.
 
-<a name="buffer" href="#buffer">#</a> d3.<b>buffer</b>(<i>input</i>[, <i>init</i>]) [<>](https://github.com/d3/d3-fetch/blob/master/src/buffer.js "Source")
+<a name="buffer" href="#buffer">#</a> d3.<b>buffer</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/buffer.js "Source")
 
 Fetches the binary file at the specified *input* URL as an ArrayBuffer. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.
 
-<a name="csv" href="#csv">#</a> d3.<b>csv</b>(<i>input</i>[, <i>init</i>][, <i>row</i>]) [<>](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source")
+<a name="csv" href="#csv">#</a> d3.<b>csv</b>(<i>input</i>[, <i>init</i>][, <i>row</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source")
 
 Equivalent to [d3.dsv](#dsv) with the comma character as the delimiter.
 
-<a name="dsv" href="#dsv">#</a> d3.<b>dsv</b>(<i>delimiter</i>, <i>input</i>[, <i>init</i>][, <i>row</i>]) [<>](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source")
+<a name="dsv" href="#dsv">#</a> d3.<b>dsv</b>(<i>delimiter</i>, <i>input</i>[, <i>init</i>][, <i>row</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source")
 
 Fetches the [DSV](https://github.com/d3/d3-dsv) file at the specified *input* URL. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields. An optional *row* conversion function may be specified to map and filter row objects to a more-specific representation; see [*dsv*.parse](https://github.com/d3/d3-dsv#dsv_parse) for details. For example:
 
@@ -69,11 +69,11 @@ If only one of *init* and *row* is specified, it is interpreted as the *row* con
 
 See also [d3.csv](#csv) and [d3.tsv](#tsv).
 
-<a name="html" href="#html">#</a> d3.<b>html</b>(<i>input</i>[, <i>init</i>]) [<>](https://github.com/d3/d3-fetch/blob/master/src/xml.js "Source")
+<a name="html" href="#html">#</a> d3.<b>html</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/xml.js "Source")
 
 Fetches the file at the specified *input* URL as [text](#text) and then [parses it](https://developer.mozilla.org/docs/Web/API/DOMParser) as HTML. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.
 
-<a name="image" href="#image">#</a> d3.<b>image</b>(<i>input</i>[, <i>init</i>]) [<>](https://github.com/d3/d3-fetch/blob/master/src/image.js "Source")
+<a name="image" href="#image">#</a> d3.<b>image</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/image.js "Source")
 
 Fetches the image at the specified *input* URL. If *init* is specified, sets any additional properties on the image before loading. For example, to enable an anonymous [cross-origin request](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image):
 
@@ -83,22 +83,22 @@ d3.image("https://example.com/test.png", {crossOrigin: "anonymous"}).then(functi
 });
 ```
 
-<a name="json" href="#json">#</a> d3.<b>json</b>(<i>input</i>[, <i>init</i>]) [<>](https://github.com/d3/d3-fetch/blob/master/src/json.js "Source")
+<a name="json" href="#json">#</a> d3.<b>json</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/json.js "Source")
 
 Fetches the [JSON](http://json.org) file at the specified *input* URL. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields. If the server returns a status code of [204 No Content](https://developer.mozilla.org/docs/Web/HTTP/Status/204) or [205 Reset Content](https://developer.mozilla.org/docs/Web/HTTP/Status/205), the promise resolves to `undefined`.
 
-<a name="svg" href="#svg">#</a> d3.<b>svg</b>(<i>input</i>[, <i>init</i>]) [<>](https://github.com/d3/d3-fetch/blob/master/src/xml.js "Source")
+<a name="svg" href="#svg">#</a> d3.<b>svg</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/xml.js "Source")
 
 Fetches the file at the specified *input* URL as [text](#text) and then [parses it](https://developer.mozilla.org/docs/Web/API/DOMParser) as SVG. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.
 
-<a name="text" href="#text">#</a> d3.<b>text</b>(<i>input</i>[, <i>init</i>]) [<>](https://github.com/d3/d3-fetch/blob/master/src/text.js "Source")
+<a name="text" href="#text">#</a> d3.<b>text</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/text.js "Source")
 
 Fetches the text file at the specified *input* URL. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.
 
-<a name="tsv" href="#tsv">#</a> d3.<b>tsv</b>(<i>input</i>[, <i>init</i>][, <i>row</i>]) [<>](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source")
+<a name="tsv" href="#tsv">#</a> d3.<b>tsv</b>(<i>input</i>[, <i>init</i>][, <i>row</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/dsv.js "Source")
 
 Equivalent to [d3.dsv](#dsv) with the tab character as the delimiter.
 
-<a name="xml" href="#xml">#</a> d3.<b>xml</b>(<i>input</i>[, <i>init</i>]) [<>](https://github.com/d3/d3-fetch/blob/master/src/xml.js "Source")
+<a name="xml" href="#xml">#</a> d3.<b>xml</b>(<i>input</i>[, <i>init</i>]) · [Source](https://github.com/d3/d3-fetch/blob/master/src/xml.js "Source")
 
 Fetches the file at the specified *input* URL as [text](#text) and then [parses it](https://developer.mozilla.org/docs/Web/API/DOMParser) as XML. If *init* is specified, it is passed along to the underlying call to [fetch](https://fetch.spec.whatwg.org/#fetch-method); see [RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed fields.


### PR DESCRIPTION
POC for [Add version info to API reference. #3452](https://github.com/d3/d3/issues/3452).

The changes add a _"Since vx.x.x"_ info text to each method as described in above mentioned issue on the main bundle. The information was gathered by browsing through the tagged releases of this module.